### PR TITLE
Add lazy option for thumbnails

### DIFF
--- a/lib/Foswiki/Plugins/PhotoGalleryPlugin/Config.spec
+++ b/lib/Foswiki/Plugins/PhotoGalleryPlugin/Config.spec
@@ -31,5 +31,8 @@ $Foswiki::cfg{Plugins}{PhotoGalleryPlugin}{AdminDefault} = 'user';
 # Default <code>size</code> parameter (thumbnail size) for <a href="view/System/VarPHOTOGALLERY"><code>%PHOTOGALLERY%</code></a> (50..500).
 $Foswiki::cfg{Plugins}{PhotoGalleryPlugin}{SizeDefault} = 150;
 
+# **BOOLEAN**
+# Default <code>lazy</code> parameter. <code>on</code> uses rest interfave to delay thumbnail creation untill after the page is rendered. <code>off</code> resizes images and then returns the page.
+$Foswiki::cfg{Plugins}{PhotoGalleryPlugin}{LazyDefault} = '1';
 
 1;


### PR DESCRIPTION
Added a lazy option for thumbnails.
Default <code>lazy="on"</code> will use the Foswiki rest interface to scale and retrieve the thumbnails for the gallery as per the original design.
<code>lazy="off"</code> will scale the thumnails as part of the original topic request.